### PR TITLE
Add option to disable item drops while bones_mode=bones

### DIFF
--- a/death.lua
+++ b/death.lua
@@ -153,7 +153,7 @@ minetest.register_on_dieplayer(function(player)
 		bones_pos = find_replaceable_pos(pos)
 	end
 	-- Drop items on the ground
-	if bones.mode == "drop" and bones.disable_drop ~= true and not bones_pos then
+	if bones.mode == "drop" and bones.disable_drop == false and not bones_pos then
 		for _,stack in pairs(items) do
 			drop_item(pos, stack)
 		end

--- a/death.lua
+++ b/death.lua
@@ -147,7 +147,7 @@ minetest.register_on_dieplayer(function(player)
 		bones_pos = find_replaceable_pos(pos)
 	end
 	-- Keep items if no pos is found and drops are disabled
-	if bones.disable_drop == true and not bones_pos then
+	if bones.fallback_mode == true and not bones_pos then
 		log_death(pos, name, "keep")
 		return
 	end
@@ -158,7 +158,7 @@ minetest.register_on_dieplayer(function(player)
 		return
 	end
 	-- Drop items on the ground
-	if bones.mode == "drop" or (bones.disable_drop == false and not bones_pos) then
+	if bones.mode == "drop" or (bones.fallback_mode == false and not bones_pos) then
 		for _,stack in pairs(items) do
 			drop_item(pos, stack)
 		end

--- a/death.lua
+++ b/death.lua
@@ -153,12 +153,15 @@ minetest.register_on_dieplayer(function(player)
 		bones_pos = find_replaceable_pos(pos)
 	end
 	-- Drop items on the ground
-	if bones.mode == "drop" or not bones_pos then
+	if bones.mode == "drop" and bones.disable_drop ~= true and not bones_pos then
 		for _,stack in pairs(items) do
 			drop_item(pos, stack)
 		end
 		drop_item(pos, "bones:bones")
 		log_death(pos, name, "drop")
+		return
+	elseif not bones_pos then
+		log_death(pos, name, "keep")
 		return
 	end
 	-- Place bones

--- a/death.lua
+++ b/death.lua
@@ -141,16 +141,21 @@ minetest.register_on_dieplayer(function(player)
 		log_death(pos, name, "keep")
 		return
 	end
+	-- Check if it's possible to place bones
+	local bones_pos
+	if bones.mode == "bones" then
+		bones_pos = find_replaceable_pos(pos)
+	end
+	-- Keep items if no pos is found and drops are disabled
+	if bones.disable_drop == true and not bones_pos then
+		log_death(pos, name, "keep")
+		return
+	end
 	-- Check if player has items, do nothing if they don't
 	local items = get_all_items(player)
 	if #items == 0 then
 		log_death(pos, name, "none")
 		return
-	end
-	-- Check if it's possible to place bones
-	local bones_pos
-	if bones.mode == "bones" then
-		bones_pos = find_replaceable_pos(pos)
 	end
 	-- Drop items on the ground
 	if bones.mode == "drop" or (bones.disable_drop == false and not bones_pos) then
@@ -159,9 +164,6 @@ minetest.register_on_dieplayer(function(player)
 		end
 		drop_item(pos, "bones:bones")
 		log_death(pos, name, "drop")
-		return
-	elseif not bones_pos then
-		log_death(pos, name, "keep")
 		return
 	end
 	-- Place bones

--- a/death.lua
+++ b/death.lua
@@ -153,7 +153,7 @@ minetest.register_on_dieplayer(function(player)
 		bones_pos = find_replaceable_pos(pos)
 	end
 	-- Drop items on the ground
-	if bones.mode == "drop" and bones.disable_drop == false and not bones_pos then
+	if bones.mode == "drop" or (bones.disable_drop == false and not bones_pos) then
 		for _,stack in pairs(items) do
 			drop_item(pos, stack)
 		end

--- a/init.lua
+++ b/init.lua
@@ -6,10 +6,15 @@ bones = {
 	waypoint_time = tonumber(minetest.settings:get("bones_waypoint_time")) or 3600,
 	mode = minetest.settings:get("bones_mode") or "bones",
 	position_message = minetest.settings:get_bool("bones_position_message", true),
+	disable_drop = minetest.settings:get_bool("bones_disable_drop", false),
 }
 
 if bones.mode ~= "bones" and bones.mode ~= "drop" and bones.mode ~= "keep" then
 	bones.mode = "bones"
+end
+
+if bones.mode ~= "bones" and bones.disable_drop ~= false then
+	bones.disable_drop = false
 end
 
 local MP = minetest.get_modpath("bones")

--- a/init.lua
+++ b/init.lua
@@ -6,15 +6,15 @@ bones = {
 	waypoint_time = tonumber(minetest.settings:get("bones_waypoint_time")) or 3600,
 	mode = minetest.settings:get("bones_mode") or "bones",
 	position_message = minetest.settings:get_bool("bones_position_message", true),
-	disable_drop = minetest.settings:get_bool("bones_disable_drop", false),
+	fallback_mode = minetest.settings:get_bool("bones_fallback_mode", false),
 }
 
 if bones.mode ~= "bones" and bones.mode ~= "drop" and bones.mode ~= "keep" then
 	bones.mode = "bones"
 end
 
-if bones.mode ~= "bones" and bones.disable_drop ~= false then
-	bones.disable_drop = false
+if bones.mode ~= "bones" and bones.fallback_mode ~= false then
+	bones.fallback_mode = false
 end
 
 local MP = minetest.get_modpath("bones")

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -16,4 +16,4 @@ bones_position_message (Bones message) bool true
 bones_waypoint_time (Bones waypoint time) int 3600 0
 
 # Disable item drops (requires 'bones_mode=bones')
-bones_disable_drop (Disable item drops - requires 'bones_mode=bones') bool false
+bones_fallback_mode (Disable item drops - requires 'bones_mode=bones') bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -14,3 +14,6 @@ bones_position_message (Bones message) bool true
 # The time in seconds that bone waypoints will be shown.
 # Setting this to 0 will disable waypoints.
 bones_waypoint_time (Bones waypoint time) int 3600 0
+
+# Disable item drops (requires 'bones_mode=bones')
+bones_disable_drop (Disable item drops - requires 'bones_mode=bones') bool false


### PR DESCRIPTION
Would fix problems like https://github.com/Archtec-io/bugtracker/issues/114

Explanation:
This PR allows admins to disable the drop mode. For example on my server we only need the "bones" and "keep" mode as fallback.