### PR TITLE
support updating waypoints when bones are moved

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,7 +1,7 @@
 unused_args = false
 
 globals = {
-    "minetest",
+	"core", "minetest",
 	"bones",
 }
 

--- a/bones.lua
+++ b/bones.lua
@@ -85,7 +85,7 @@ minetest.register_node("bones:bones", {
 	end,
 	on_blast = function() end,
 	on_movenode = function(from_pos, to_pos)
-		local meta = core.get_meta(from_pos)
+		local meta = core.get_meta(to_pos)
 		local owner = meta:get_string("owner")
 		-- Don't bother with empty (decorative) bones.
 		-- Possibly it would be better to check infotext or inventory emptyness.

--- a/bones.lua
+++ b/bones.lua
@@ -83,23 +83,22 @@ minetest.register_node("bones:bones", {
 			bones.remove_waypoint(pos, player)
 		end
 	end,
-	on_blast = function() end,
 	on_movenode = function(from_pos, to_pos)
 		local meta = core.get_meta(to_pos)
 		local owner = meta:get_string("owner")
-		-- Don't bother with empty (decorative) bones.
-		-- Possibly it would be better to check infotext or inventory emptyness.
+		-- Ignore empty (decorative) bones.
 		if owner == "" then
 			return
 		end
-
 		local player = core.get_player_by_name(owner)
 		if player then
 			bones.remove_waypoint(from_pos, player)
 			bones.add_waypoint(to_pos, player)
 		end
-		core.log("action", "Bones of " .. owner .. " moved from "
-			.. core.pos_to_string(from_pos) .. " to "
-			.. core.pos_to_string(to_pos))
+		
+		local from = core.pos_to_string(from_pos)
+		local to = core.pos_to_string(to_pos)
+		core.log("action", "Bones of "..owner.." moved from "..from.." to "..to)
 	end,
+	on_blast = function() end,
 })

--- a/bones.lua
+++ b/bones.lua
@@ -95,7 +95,6 @@ minetest.register_node("bones:bones", {
 			bones.remove_waypoint(from_pos, player)
 			bones.add_waypoint(to_pos, player)
 		end
-		
 		local from = core.pos_to_string(from_pos)
 		local to = core.pos_to_string(to_pos)
 		core.log("action", "Bones of "..owner.." moved from "..from.." to "..to)

--- a/bones.lua
+++ b/bones.lua
@@ -87,6 +87,12 @@ minetest.register_node("bones:bones", {
 	on_movenode = function(from_pos, to_pos)
 		local meta = core.get_meta(from_pos)
 		local owner = meta:get_string("owner")
+		-- Don't bother with empty (decorative) bones.
+		-- Possibly it would be better to check infotext or inventory emptyness.
+		if owner == "" then
+			return
+		end
+
 		local player = core.get_player_by_name(owner)
 		if player then
 			bones.remove_waypoint(from_pos, player)

--- a/bones.lua
+++ b/bones.lua
@@ -84,4 +84,16 @@ minetest.register_node("bones:bones", {
 		end
 	end,
 	on_blast = function() end,
+	on_movenode = function(from_pos, to_pos)
+		local meta = core.get_meta(from_pos)
+		local owner = meta:get_string("owner")
+		local player = core.get_player_by_name(owner)
+		if player then
+			bones.remove_waypoint(from_pos, player)
+			bones.add_waypoint(to_pos, player)
+		end
+		core.log("action", "Bones of " .. owner .. " moved from "
+			.. core.pos_to_string(from_pos) .. " to "
+			.. core.pos_to_string(to_pos))
+	end,
 })


### PR DESCRIPTION
This PR handles bones moved by [jumpdrive] and potentially any other mod that uses the ``on_movenode`` method in node-def.

- logs the move
- if owner is online:
  - removes old waypoint
  - adds new waypoint

As waypoints are stored in player meta, there is currently no way to update waypoints of offline players. There is a way to cache changes - maybe a followup PR will solve this or at least improve on this PR.