### PR TITLE
fix typo obituary.lua

### DIFF
--- a/obituary.lua
+++ b/obituary.lua
@@ -16,7 +16,7 @@ local function show_obituary_formspec(stack, player)
 	local meta = stack:get_meta()
 	local name = meta:get_string("name")
 	local time = os.date("%Y/%m/%d  %H:%M:%S", tonumber(meta:get_string("time")) or 0)
-	local pos = core.string_to_pos(meta:get_string("pos")) or vector.zero
+	local pos = core.string_to_pos(meta:get_string("pos")) or vector.zero()
 	local items = meta:get_string("items")
 	local fs = formspec:format(name, time, pos.x, pos.y, pos.z, items)
 	core.show_formspec(player:get_player_name(), "obituary", fs)


### PR DESCRIPTION
Could lead to crash in creative mode.
```
ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'bones' in callback item_OnUse(): .../bones/obituary.lua:21: attempt to index local 'pos' (a function value)
ERROR[Main]: stack traceback:
ERROR[Main]: 	.../bones/obituary.lua:21: in function <.../bones/obituary.lua:15>
```

Thanks to @jolethen for bringing it to our attention.
Closes #17